### PR TITLE
find libhandlebars location using pkg-config

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -14,6 +14,20 @@ AC_DEFUN([PHP_HANDLEBARS_ADD_SOURCES], [
 
 # MAIN -------------------------------------------------------------------------
 if test "$PHP_HANDLEBARS" != "no"; then
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+
+    AC_MSG_CHECKING([for libhandlebars])
+    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists handlebars; then
+        LIBHANDLEBARS_CFLAGS=`$PKG_CONFIG handlebars --cflags`
+        LIBHANDLEBARS_LIBS=`$PKG_CONFIG handlebars --libs`
+        LIBHANDLEBARS_VERSION=`$PKG_CONFIG handlebars --modversion`
+        AC_MSG_RESULT(version $LIBHANDLEBARS_VERSION found using pkg-config)
+        PHP_EVAL_LIBLINE($LIBHANDLEBARS_LIBS, HANDLEBARS_SHARED_LIBADD)
+        PHP_EVAL_INCLINE($LIBHANDLEBARS_CFLAGS)
+    else
+        AC_MSG_ERROR([libhandlebars not found])
+    fi
+
 	PHP_HANDLEBARS_ADD_SOURCES([
 		php_handlebars.c
 		impl.c
@@ -32,7 +46,6 @@ if test "$PHP_HANDLEBARS" != "no"; then
 		value.c
 	])
     PHP_INSTALL_HEADERS([ext/handlebars], [php_handlebars.h])
-    PHP_ADD_LIBRARY(handlebars, 1, HANDLEBARS_SHARED_LIBADD)
     PHP_NEW_EXTENSION(handlebars, $PHP_HANDLEBARS_SOURCES, $ext_shared)
     if test "$PHP_HANDLEBARS_PSR" != "no"; then
         PHP_ADD_EXTENSION_DEP(handlebars, psr, true)

--- a/package.xml
+++ b/package.xml
@@ -87,7 +87,7 @@ Initial PECL release
   <required>
    <php>
     <min>5.6.0</min>
-    <max>7.1.99</max>
+    <max>7.2.99</max>
    </php>
    <pearinstaller>
     <min>1.4.1</min>


### PR DESCRIPTION
No check in current version :(

I only implement the pkg-config way, which seems (to me) the most reliable (and simpler that having to implement and new --with-libhandlebars option)