### PR TITLE
Add link to remi's repo for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ sudo apt-get install php-handlebars
 ```
 
 
+### Fedora
+
+The extension is available in [Remi's repository](https://rpms.remirepo.net/) (change 24 to match your Fedora version)
+
+```bash
+dnf install https://rpms.remirepo.net/fedora/remi-release-24.rpm
+dnf install --enablerepo=remi php-pecl-handlebars
+```
+
+
 ### Source
 
 Install [handlebars.c](https://github.com/jbboehr/handlebars.c)


### PR DESCRIPTION
I usually only propose to add link to official repository when the package is available there.

But as you also have a link to your PPA for Ubuntu, could male sense to add this for Fedora users

I didn't add information for RHEL/CentOS (also available), as it is not available for default PHP version (5.4).