### PR TITLE
Implement method lookup to closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## [Unreleased]
 
 ## Added
-- Property lookup now generates a closure from a method if the value of the property is null or does not exist to emulate the behaviour of javascript where functions and properties share a symbol table
+- Property lookup now generates a closure from a method if the value of the property is null or does not exist to emulate the behaviour of javascript where functions and properties share a symbol table - only supported for PHP 7 or greater
 
 ## [0.8.1] - 2016-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 
-## Added
+### Added
 - Mustache delimiter preprocessing support behind the compat flag
 - Property lookup now generates a closure from a method if the value of the property is null or does not exist to emulate the behaviour of javascript where functions and properties share a symbol table - only supported for PHP 7 or greater
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 
+## Added
+- Property lookup now generates a closure from a method if the value of the property is null or does not exist to emulate the behaviour of javascript where functions and properties share a symbol table
+
 ## [0.8.1] - 2016-11-08
 
 ### Fixed

--- a/tests/method-lookup.phpt
+++ b/tests/method-lookup.phpt
@@ -1,7 +1,7 @@
 --TEST--
 method lookup (GH-34)
 --SKIPIF--
-<?php if( !extension_loaded('handlebars') ) die('skip '); ?>
+<?php if( !extension_loaded('handlebars') || version_compare(PHP_VERSION, "7", "<") ) die('skip '); ?>
 --FILE--
 <?php
 use Handlebars\DefaultRegistry;

--- a/tests/method-lookup.phpt
+++ b/tests/method-lookup.phpt
@@ -1,0 +1,32 @@
+--TEST--
+method lookup (GH-34)
+--SKIPIF--
+<?php if( !extension_loaded('handlebars') ) die('skip '); ?>
+--FILE--
+<?php
+use Handlebars\DefaultRegistry;
+use Handlebars\VM;
+class Foo {
+    private $baz = 'bat';
+    public function bar() {
+        return $this->baz;
+    }
+    private function privateBar() {
+        return 'private' . $this->baz;
+    }
+}
+
+$vm = new VM();
+$ret = $vm->render('{{foo.bar}}', array(
+    'foo' => new Foo(),
+));
+var_dump($ret);
+
+$vm = new VM();
+$ret = $vm->render('{{foo.privateBar}}', array(
+    'foo' => new Foo(),
+));
+var_dump($ret);
+--EXPECT--
+string(3) "bat"
+string(0) ""


### PR DESCRIPTION
Closes #34 

Property lookup now generates a closure from a method if the value of the property is null or does not exist to emulate the behaviour of javascript where functions and properties share a symbol table - only supported for PHP 7 or greater