### PR TITLE
switch to zend_register_class_alias, fix for PHP 7.3

### DIFF
--- a/registry.c
+++ b/registry.c
@@ -31,8 +31,8 @@ PHP_MINIT_FUNCTION(handlebars_registry)
     zend_class_implements(HandlebarsDefaultRegistry_ce_ptr TSRMLS_CC, 1, HandlebarsRegistry_ce_ptr);
 
     // Add aliases for old class names
-    zend_register_class_alias_ex(ZEND_STRL("Handlebars\\Registry\\Registry"), HandlebarsRegistry_ce_ptr TSRMLS_CC);
-    zend_register_class_alias_ex(ZEND_STRL("Handlebars\\Registry\\DefaultRegistry"), HandlebarsDefaultRegistry_ce_ptr TSRMLS_CC);
+    zend_register_class_alias("Handlebars\\Registry\\Registry", HandlebarsRegistry_ce_ptr TSRMLS_CC);
+    zend_register_class_alias("Handlebars\\Registry\\DefaultRegistry", HandlebarsDefaultRegistry_ce_ptr TSRMLS_CC);
 
     return SUCCESS;
 }


### PR DESCRIPTION
In PHP < 7.3
`ZEND_API int zend_register_class_alias_ex(const char *name, size_t name_len, zend_class_entry *ce);`
In PHP >= 7.3
`ZEND_API int zend_register_class_alias_ex(const char *name, size_t name_len, zend_class_entry *ce, int persistent);`

So using `zend_register_class_alias` allow build with all versions (tested with 5.6 and 7.3)