### PR TITLE
Remove old backwards-compatibility class aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 
+### Removed
+- Class aliases `Handlebars\Registry\Registry` for `Handlebars\Registry` and `Handlebars\Registry\DefaultRegistry` for `Handlebars\DefaultRegistry`
+
 ## [0.8.2] - 2018-02-22
 
 ### Added

--- a/registry.c
+++ b/registry.c
@@ -30,10 +30,6 @@ PHP_MINIT_FUNCTION(handlebars_registry)
     HandlebarsDefaultRegistry_ce_ptr = php5to7_register_internal_class_ex(&ce, spl_ce_ArrayObject);
     zend_class_implements(HandlebarsDefaultRegistry_ce_ptr TSRMLS_CC, 1, HandlebarsRegistry_ce_ptr);
 
-    // Add aliases for old class names
-    zend_register_class_alias_ex(ZEND_STRL("Handlebars\\Registry\\Registry"), HandlebarsRegistry_ce_ptr TSRMLS_CC);
-    zend_register_class_alias_ex(ZEND_STRL("Handlebars\\Registry\\DefaultRegistry"), HandlebarsDefaultRegistry_ce_ptr TSRMLS_CC);
-
     return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
- Handlebars\Registry\Registry
- Handlebars\Registry\DefaultRegistry

Closes #53 