### PR TITLE
Omit passing options into regular helpers in certain cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
       - NIX_PHP_ATTR=php
   include:
   - language: php
-    php: '7.1'
-  - language: php
     php: '7.2'
   - language: php
     php: '7.3'
@@ -23,10 +21,6 @@ matrix:
     php: '7.4'
   - language: php
     php: 'master'
-  - language: nix
-    env:
-    - NIX_CHANNEL=18.09
-    - NIX_PHP_ATTR=php71
   - language: nix
     env:
     - NIX_CHANNEL=18.09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
 - Preliminary PHP 8 support
 
+### Changed
+- Drop max PHP version constraint from PECL
+- Selective helper options omission - If the argument is a closure: we will omit passing the options
+object if it will go into a slot with an incompatible type. If the argument is a callable object: we will append the
+options if the appended parameter will go into a declared parameter with either no type signature or explicitly
+typed with `Handlebars\Options`. This will allow some standard helpers to have typed default arguments while still allowing
+access to the Options object for other helpers. See `tests/helper-with-options.phpt` for details.
+
 ### Removed
-- PHP 5 support, require at least PHP 7.1
+- PHP 5 support, require at least PHP 7.2
 
 ## [0.8.3] - 2018-11-11
 

--- a/ci.nix
+++ b/ci.nix
@@ -51,18 +51,6 @@ builtins.mapAttrs (k: _v:
   pkgs.recurseIntoAttrs {
     peclDist = phpHandlebarsSrc;
 
-    php71 = let
-        path = builtins.fetchTarball {
-           url = https://github.com/NixOS/nixpkgs/archive/release-19.03.tar.gz;
-           name = "nixpkgs-19.03";
-        };
-        pkgs = import (path) { system = k; };
-        php = pkgs.php71;
-    in generateHandlebarsTestsForPlatform {
-        inherit pkgs php phpHandlebarsSrc;
-        buildPecl = pkgs.callPackage "${path}/pkgs/build-support/build-pecl.nix" { inherit php; };
-    };
-
     php72 = let
         php = pkgs.php72;
     in generateHandlebarsTestsForPlatform {

--- a/package.xml
+++ b/package.xml
@@ -1270,8 +1270,7 @@
  <dependencies>
   <required>
    <php>
-    <min>7.1.0</min>
-    <max>7.3.99</max>
+    <min>7.2.0</min>
    </php>
    <pearinstaller>
     <min>1.4.1</min>

--- a/tests/helper-with-options.phpt
+++ b/tests/helper-with-options.phpt
@@ -1,0 +1,65 @@
+--TEST--
+helper with options
+--SKIPIF--
+<?php if( !extension_loaded('handlebars') ) die('skip '); ?>
+--FILE--
+<?php
+use Handlebars\DefaultRegistry;
+use Handlebars\VM;
+$vm = new VM();
+class TestHelperNoTypesNonClosure {
+    public function __invoke($a) {
+        var_dump(func_num_args());
+        var_dump($a);
+    }
+}
+$helpers = new DefaultRegistry(array(
+    'testHelperNoTypes' => function($a) {
+        var_dump(func_num_args());
+        var_dump($a);
+        var_dump(gettype(func_get_arg(1)));
+        var_dump(get_class(func_get_arg(1)));
+    },
+    'testHelperNoTypesNonClosure' => new TestHelperNoTypesNonClosure(),
+    'testHelperWithOptionsType' => function($a, \Handlebars\Options $b) {
+        var_dump(func_num_args());
+        var_dump($a);
+        var_dump(gettype($b));
+        var_dump(get_class($b));
+    },
+    'testHelperWithInvalidArgType' => function(string $a, string $b = null) {
+        var_dump(func_num_args());
+        var_dump($a);
+        var_dump(gettype($b));
+    },
+    'testHelperWithExtraArg' => function($a, $b) {
+        var_dump(func_num_args());
+        var_dump($a);
+        var_dump(gettype($b));
+        var_dump(get_class($b));
+    },
+));
+$vm->setHelpers($helpers);
+$vm->render('{{testHelperNoTypes "foo"}}');
+$vm->render('{{testHelperNoTypesNonClosure "foo"}}');
+$vm->render('{{testHelperWithOptionsType "foo"}}');
+$vm->render('{{testHelperWithInvalidArgType "foo"}}');
+$vm->render('{{testHelperWithExtraArg "foo"}}');
+--EXPECT--
+int(2)
+string(3) "foo"
+string(6) "object"
+string(18) "Handlebars\Options"
+int(1)
+string(3) "foo"
+int(2)
+string(3) "foo"
+string(6) "object"
+string(18) "Handlebars\Options"
+int(1)
+string(3) "foo"
+string(4) "NULL"
+int(2)
+string(3) "foo"
+string(6) "object"
+string(18) "Handlebars\Options"


### PR DESCRIPTION
If the argument is a closure: we will omit passing the options
object if it will go into a slot with an incompatible type
If the argument is a callable object: we will append the
options if the appended parameter will go into a
declared parameter with either no type signature or explicitly
typed with Handlebars\Options