### PR TITLE
Make sure deterministic pointers test works

### DIFF
--- a/handlebars.stub.php
+++ b/handlebars.stub.php
@@ -24,6 +24,11 @@ const VERSION = "x.y.z";
 const LIBVERSION = "x.y.z";
 
 /**
+ * libhandlebars version (at compile time)
+ */
+const LIBVERSION2 = "x.y.z";
+
+/**
  * If PSR extension is available
  */
 const PSR = true;

--- a/php_handlebars.c
+++ b/php_handlebars.c
@@ -95,6 +95,7 @@ static PHP_MINIT_FUNCTION(handlebars)
 
     REGISTER_STRING_CONSTANT("Handlebars\\VERSION", (char *) PHP_HANDLEBARS_VERSION, flags);
     REGISTER_STRING_CONSTANT("Handlebars\\LIBVERSION", (char *) version, flags);
+    REGISTER_STRING_CONSTANT("Handlebars\\LIBVERSION2", (char *) HANDLEBARS_VERSION_STRING, flags);
 
     // Setup root contexts
     HANDLEBARS_G(root) = talloc_new(NULL);
@@ -180,6 +181,7 @@ static PHP_MINFO_FUNCTION(handlebars)
     php_info_print_table_row(2, "Spec Version", PHP_HANDLEBARS_SPEC);
     php_info_print_table_row(2, "PSR support", handlebars_has_psr ? "active" : "inactive");
     php_info_print_table_row(2, "libhandlebars Version", handlebars_version_string());
+    php_info_print_table_row(2, "libhandlebars Version (compile-time)", HANDLEBARS_VERSION_STRING);
     php_info_print_table_row(2, "libhandlebars Handlebars Spec Version", handlebars_spec_version_string());
     php_info_print_table_row(2, "libhandlebars Mustache Spec Version", handlebars_mustache_spec_version_string());
 

--- a/tests/phpinfo-no-cache.phpt
+++ b/tests/phpinfo-no-cache.phpt
@@ -18,6 +18,7 @@ Authors => %s
 Spec Version => %s
 PSR support => %s
 libhandlebars Version => %s
+libhandlebars Version (compile-time) => %s
 libhandlebars Handlebars Spec Version => %s
 libhandlebars Mustache Spec Version => %s
 xxhash version => %s

--- a/tests/phpinfo.phpt
+++ b/tests/phpinfo.phpt
@@ -18,6 +18,7 @@ Authors => %s
 Spec Version => %s
 PSR support => %s
 libhandlebars Version => %s
+libhandlebars Version (compile-time) => %s
 libhandlebars Handlebars Spec Version => %s
 libhandlebars Mustache Spec Version => %s
 xxhash version => %s

--- a/tests/vm/renderFromBinaryString.phpt
+++ b/tests/vm/renderFromBinaryString.phpt
@@ -10,7 +10,7 @@ $binaryString = $vm->compile(file_get_contents(__DIR__ . '/../fixture1.hbs'));
 var_dump($vm->renderFromBinaryString($binaryString, array('foo' => 'bar')));
 
 // We want the serialized buffer to be deterministic
-if (version_compare(Handlebars\LIBVERSION, "0.7.1", ">=")) {
+if (version_compare(Handlebars\LIBVERSION2, "0.7.1", ">=")) {
     var_dump($binaryString === $vm->compile(file_get_contents(__DIR__ . '/../fixture1.hbs')));
 } else {
     var_dump(true); // just consider this skipped


### PR DESCRIPTION
Should only run if the extension is *compiled* against
handlebars.c >= 0.7.1

See #70