### PR TITLE
Fix  Implicitly marking parameter $.. as nullable is deprecated

### DIFF
--- a/tests/base-impl/fake-impl.php.inc
+++ b/tests/base-impl/fake-impl.php.inc
@@ -1,6 +1,6 @@
 <?php
 
 class FakeImpl extends Handlebars\BaseImpl {
-    public function render(string $tmpl, $context = null, array $options = null): string {}
-    public function renderFile(string $filename, $context = null, array $options = null): string {}
+    public function render(string $tmpl, $context = null, ?array $options = null): string {}
+    public function renderFile(string $filename, $context = null, ?array $options = null): string {}
 }

--- a/tests/helper-with-options-union.phpt
+++ b/tests/helper-with-options-union.phpt
@@ -17,7 +17,7 @@ $helpers = new DefaultRegistry(array(
     'testHelperWithUnionType2' => function(string $a, string|int|null $b = null) {
         var_dump(func_num_args());
     },
-    'testHelperWithUnionType3' => function(string $a, stdClass|Handlebars\Options $b = null) {
+    'testHelperWithUnionType3' => function(string $a, stdClass|Handlebars\Options|null $b = null) {
         var_dump(func_num_args());
     },
 ));

--- a/tests/helper-with-options.phpt
+++ b/tests/helper-with-options.phpt
@@ -27,7 +27,7 @@ $helpers = new DefaultRegistry(array(
         var_dump(gettype($b));
         var_dump(get_class($b));
     },
-    'testHelperWithInvalidArgType' => function(string $a, string $b = null) {
+    'testHelperWithInvalidArgType' => function(string $a, ?string $b = null) {
         var_dump(func_num_args());
         var_dump($a);
         var_dump(gettype($b));

--- a/tests/vm/__construct-without-psr.phpt
+++ b/tests/vm/__construct-without-psr.phpt
@@ -11,11 +11,11 @@ if( extension_loaded('psr') ) die('skip ');
 namespace Psr\Log;
 
 interface LoggerInterface {
-    public function log($level, $message, array $context = null);
+    public function log($level, $message, ?array $context = null);
 }
 abstract class AbstractLogger implements LoggerInterface {
-    public function info($message, array $context = null) { $this->log('info', $message, $context); }
-    public function warning($message, array $context = null) { $this->log('warning', $message, $context); }
+    public function info($message, ?array $context = null) { $this->log('info', $message, $context); }
+    public function warning($message, ?array $context = null) { $this->log('warning', $message, $context); }
 }
 
 namespace IgnoreMe;
@@ -25,7 +25,7 @@ use Handlebars\VM;
 use Psr\Log\AbstractLogger;
 
 class TestLogger extends AbstractLogger {
-    public function log($level, $message, array $context = null) { var_dump($level, $message); }
+    public function log($level, $message, ?array $context = null) { var_dump($level, $message); }
 }
 
 $helpers = new DefaultRegistry();

--- a/tests/vm/setLogger-without-psr.phpt
+++ b/tests/vm/setLogger-without-psr.phpt
@@ -6,18 +6,18 @@ Handlebars\VM::setLogger() without php-psr
 <?php
 namespace Psr\Log;
 interface LoggerInterface {
-    public function log($level, $message, array $context = null);
+    public function log($level, $message, ?array $context = null);
 }
 abstract class AbstractLogger implements LoggerInterface {
-    public function info($message, array $context = null) { $this->log('info', $message, $context); }
-    public function warning($message, array $context = null) { $this->log('warning', $message, $context); }
+    public function info($message, ?array $context = null) { $this->log('info', $message, $context); }
+    public function warning($message, ?array $context = null) { $this->log('warning', $message, $context); }
 }
 
 namespace Invalid;
 use Psr\Log\AbstractLogger;
 use Handlebars\VM;
 class TestLogger extends AbstractLogger {
-    public function log($level, $message, array $context = null) { var_dump($level, $message); }
+    public function log($level, $message, ?array $context = null) { var_dump($level, $message); }
 }
 $logger = new TestLogger();
 $vm = new VM();


### PR DESCRIPTION
For PHP  8.4.0alpha1

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :     0
Exts tested     :    17
---------------------------------------------------------------------

Number of tests :  1402               574
Tests skipped   :   828 ( 59.1%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     0 (  0.0%) (  0.0%)
Tests passed    :   574 ( 40.9%) (100.0%)
---------------------------------------------------------------------
Time taken      : 9.774 seconds
=====================================================================

```